### PR TITLE
[go.mod] bump to v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The v2 release contains breaking changes. The most important ones are:
 ## Usage
 
 ```bash
-go get github.com/leonsteinhaeuser/observer
+go get github.com/leonsteinhaeuser/observer/v2
 ```
 
 ## Example
@@ -32,7 +32,7 @@ package main
 
 import (
     "fmt"
-    "github.com/leonsteinhaeuser/observer"
+    "github.com/leonsteinhaeuser/observer/v2"
 )
 
 type Event struct {

--- a/_example/basic/main.go
+++ b/_example/basic/main.go
@@ -5,7 +5,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/leonsteinhaeuser/observer"
+	"github.com/leonsteinhaeuser/observer/v2"
 )
 
 const (

--- a/_example/handler/main.go
+++ b/_example/handler/main.go
@@ -8,7 +8,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/go-multierror"
-	"github.com/leonsteinhaeuser/observer"
+	"github.com/leonsteinhaeuser/observer/v2"
 	"golang.org/x/sync/errgroup"
 )
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/leonsteinhaeuser/observer
+module github.com/leonsteinhaeuser/observer/v2
 
 go 1.18
 


### PR DESCRIPTION
Hello again! Please consider putting /v2 into go.mod file, since we're moving on to v2 API. It might be necessary to add v2.0.1 tag that points to that commit, too.